### PR TITLE
fix: update deploy-docker.sh to only stop specific container instances

### DIFF
--- a/deployment/deploy-docker.sh
+++ b/deployment/deploy-docker.sh
@@ -147,9 +147,28 @@ fi
 # Create logs directory
 mkdir -p logs
 
-# Stop existing containers
-echo -e "${YELLOW}Stopping existing containers...${NC}"
-$DOCKER_COMPOSE down --remove-orphans 2>/dev/null || true
+# Stop existing instances of this container only
+echo -e "${YELLOW}Stopping existing instances of encoder-server...${NC}"
+
+# Stop and remove encoder-server container if it exists
+if docker ps -a --format '{{.Names}}' | grep -q '^encoder-server$'; then
+    echo -e "${YELLOW}  Stopping encoder-server container...${NC}"
+    docker stop encoder-server 2>/dev/null || true
+    docker rm encoder-server 2>/dev/null || true
+    echo -e "${GREEN}  ✓ encoder-server stopped and removed${NC}"
+fi
+
+# Stop and remove encoder-nginx container if it exists (for --with-nginx deployments)
+if docker ps -a --format '{{.Names}}' | grep -q '^encoder-nginx$'; then
+    echo -e "${YELLOW}  Stopping encoder-nginx container...${NC}"
+    docker stop encoder-nginx 2>/dev/null || true
+    docker rm encoder-nginx 2>/dev/null || true
+    echo -e "${GREEN}  ✓ encoder-nginx stopped and removed${NC}"
+fi
+
+# Clean up unused networks for this project only
+docker network ls --format '{{.Name}}' | grep -q '^deployment_encoder-network$' && \
+    docker network rm deployment_encoder-network 2>/dev/null || true
 
 # Build and start containers
 if [ "$FORCE_BUILD" = true ]; then


### PR DESCRIPTION
Changed the deployment script to stop only encoder-server and encoder-nginx containers by name instead of using 'docker compose down' which could affect other running containers. Now the script:
- Stops only containers with exact names: encoder-server, encoder-nginx
- Removes only the specific project network
- Does not interfere with other running containers on the system