### PR TITLE
fix: clamp window height within 15cm tolerance instead of rejecting

### DIFF
--- a/src/components/geometry/window_geometry.py
+++ b/src/components/geometry/window_geometry.py
@@ -127,10 +127,24 @@ class WindowGeometry:
         """Get z1 coordinate"""
         return self._corner1.z
 
+    @z1.setter
+    def z1(self, value: float) -> None:
+        """Set z1 coordinate and update cached z bounds."""
+        self._corner1.z = value
+        self._z_min = min(self._corner1.z, self._corner2.z)
+        self._z_max = max(self._corner1.z, self._corner2.z)
+
     @property
     def z2(self) -> float:
         """Get z2 coordinate"""
         return self._corner2.z
+
+    @z2.setter
+    def z2(self, value: float) -> None:
+        """Set z2 coordinate and update cached z bounds."""
+        self._corner2.z = value
+        self._z_min = min(self._corner1.z, self._corner2.z)
+        self._z_max = max(self._corner1.z, self._corner2.z)
 
     @property
     def niche_center(self) -> Point2D:

--- a/src/components/geometry/window_height_validator.py
+++ b/src/components/geometry/window_height_validator.py
@@ -1,7 +1,10 @@
+import logging
 from typing import Tuple, Dict, Any
 from src.components.geometry.window_geometry import WindowGeometry
 from src.core import GRAPHICS_CONSTANTS
 from src.core import WindowHeightValidationError
+
+logger = logging.getLogger(__name__)
 
 
 class WindowHeightValidator:
@@ -16,6 +19,8 @@ class WindowHeightValidator:
     ) -> Tuple[bool, str]:
         """
         Validate that window z-coordinates are within floor-roof bounds.
+        Windows within WINDOW_HEIGHT_CORRECTION_TOLERANCE (15cm) are clamped
+        to floor/roof. Windows beyond that tolerance raise an error.
 
         Args:
             window_geometry: Window geometry with z1, z2 coordinates
@@ -24,40 +29,75 @@ class WindowHeightValidator:
 
         Returns:
             Tuple of (is_valid, error_message)
-            - (True, "") if window is within bounds
-            - (False, error_message) if window extends beyond floor or roof
+            - (True, "") if window is within bounds (or was clamped)
+            - (False, error_message) if window extends beyond tolerance
         """
         try:
             z1 = window_geometry.z1
             z2 = window_geometry.z2
+            tolerance = GRAPHICS_CONSTANTS.WINDOW_HEIGHT_CORRECTION_TOLERANCE
 
             window_bottom = min(z1, z2)
             window_top = max(z1, z2)
 
             # Check if window bottom is below floor
-            if window_bottom < floor_height - GRAPHICS_CONSTANTS.WINDOW_HEIGHT_TOLERANCE:
-                raise WindowHeightValidationError(
-                window_bottom=window_bottom,
-                window_top=window_top,
-                floor_height=floor_height,
-                roof_height=roof_height,
-                error_type="below_floor"
-            )
-
-        # Check if window top is above roof
-            if window_top > roof_height + GRAPHICS_CONSTANTS.WINDOW_HEIGHT_TOLERANCE:
-                raise WindowHeightValidationError(
-                window_bottom=window_bottom,
-                window_top=window_top,
-                floor_height=floor_height,
-                roof_height=roof_height,
-                error_type="above_roof"
+            if window_bottom < floor_height:
+                deviation = floor_height - window_bottom
+                if deviation > tolerance:
+                    raise WindowHeightValidationError(
+                        window_bottom=window_bottom,
+                        window_top=window_top,
+                        floor_height=floor_height,
+                        roof_height=roof_height,
+                        error_type="below_floor"
+                    )
+                logger.info(
+                    "Window bottom (%.2fm) clamped to floor (%.2fm) — deviation: %.3fm",
+                    window_bottom, floor_height, deviation
                 )
+                cls._clamp_z(window_geometry, z1, z2, floor_height, is_bottom=True)
+
+            # Check if window top is above roof
+            if window_top > roof_height:
+                deviation = window_top - roof_height
+                if deviation > tolerance:
+                    raise WindowHeightValidationError(
+                        window_bottom=window_bottom,
+                        window_top=window_top,
+                        floor_height=floor_height,
+                        roof_height=roof_height,
+                        error_type="above_roof"
+                    )
+                logger.info(
+                    "Window top (%.2fm) clamped to roof (%.2fm) — deviation: %.3fm",
+                    window_top, roof_height, deviation
+                )
+                cls._clamp_z(window_geometry, z1, z2, roof_height, is_bottom=False)
 
             return True, ""
 
         except (KeyError, ValueError, AttributeError) as e:
             return False, f"Error validating window height: {type(e).__name__}: {str(e)}"
+
+    @staticmethod
+    def _clamp_z(
+        window_geometry: WindowGeometry,
+        z1: float,
+        z2: float,
+        target: float,
+        is_bottom: bool
+    ) -> None:
+        """Clamp the bottom or top z-coordinate of the window to the target value."""
+        if is_bottom:
+            if z1 <= z2:
+                window_geometry.z1 = target
+            else:
+                window_geometry.z2 = target
+        else:
+            if z1 >= z2:
+                window_geometry.z1 = target
+            else:
+                window_geometry.z2 = target
 
     @classmethod
     def validate_from_parameters(

--- a/src/core/graphics_constants.py
+++ b/src/core/graphics_constants.py
@@ -36,7 +36,7 @@ class ImageGraphicsConstants:
 
     # Window placement tolerance (meters) for edge matching
     WINDOW_PLACEMENT_TOLERANCE: float = 0.05
-    WINDOW_HEIGHT_TOLERANCE:float =  1e-6
+    WINDOW_HEIGHT_CORRECTION_TOLERANCE: float = 0.15  # 15cm - BIM frames may extend slightly beyond floor/roof
 
     @classmethod
     def get_pixel_value(cls, value:float, 

--- a/tests/components/geometry/test_window_height_validation.py
+++ b/tests/components/geometry/test_window_height_validation.py
@@ -1,336 +1,262 @@
 """
 Unit tests for WindowHeightValidator - validates window z-coordinates are between floor and roof.
+Windows within 15cm tolerance are clamped, beyond that an error is raised.
 """
 
 import pytest
 from src.components.geometry import WindowHeightValidator, WindowGeometry
+from src.core.exceptions import WindowHeightValidationError
 
 
 class TestWindowHeightValidator:
     """Test WindowHeightValidator class."""
 
+    # --- Valid windows (no clamping needed) ---
+
     def test_window_within_bounds(self):
         """Test window that is properly within floor and roof bounds."""
         window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=1.0, x2=1.0, y2=0.0, z2=2.5)
-        floor_height = 0.0
-        roof_height = 3.0
-
         is_valid, error_msg = WindowHeightValidator.validate_window_height_bounds(
-            window_geom, floor_height, roof_height
+            window_geom, floor_height=0.0, roof_height=3.0
         )
-
         assert is_valid is True
         assert error_msg == ""
 
     def test_window_at_floor_level(self):
         """Test window that starts exactly at floor level."""
         window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=0.0, x2=1.0, y2=0.0, z2=2.0)
-        floor_height = 0.0
-        roof_height = 3.0
-
         is_valid, error_msg = WindowHeightValidator.validate_window_height_bounds(
-            window_geom, floor_height, roof_height
+            window_geom, floor_height=0.0, roof_height=3.0
         )
-
         assert is_valid is True
         assert error_msg == ""
 
     def test_window_at_roof_level(self):
         """Test window that ends exactly at roof level."""
         window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=1.0, x2=1.0, y2=0.0, z2=3.0)
-        floor_height = 0.0
-        roof_height = 3.0
-
         is_valid, error_msg = WindowHeightValidator.validate_window_height_bounds(
-            window_geom, floor_height, roof_height
+            window_geom, floor_height=0.0, roof_height=3.0
         )
-
         assert is_valid is True
         assert error_msg == ""
 
     def test_window_fills_entire_height(self):
         """Test window that spans from floor to roof."""
         window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=0.0, x2=1.0, y2=0.0, z2=3.0)
-        floor_height = 0.0
-        roof_height = 3.0
-
         is_valid, error_msg = WindowHeightValidator.validate_window_height_bounds(
-            window_geom, floor_height, roof_height
+            window_geom, floor_height=0.0, roof_height=3.0
         )
-
         assert is_valid is True
         assert error_msg == ""
-
-    def test_window_below_floor(self):
-        """Test window that extends below floor level."""
-        from src.core.exceptions import WindowHeightValidationError
-
-        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=-0.5, x2=1.0, y2=0.0, z2=2.0)
-        floor_height = 0.0
-        roof_height = 3.0
-
-        with pytest.raises(WindowHeightValidationError) as exc_info:
-            WindowHeightValidator.validate_window_height_bounds(
-                window_geom, floor_height, roof_height
-            )
-
-        error_msg = str(exc_info.value)
-        assert "below floor" in error_msg
-        assert "-0.50m" in error_msg
-        assert "0.00m" in error_msg
-
-    def test_window_above_roof(self):
-        """Test window that extends above roof level."""
-        from src.core.exceptions import WindowHeightValidationError
-
-        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=2.0, x2=1.0, y2=0.0, z2=3.5)
-        floor_height = 0.0
-        roof_height = 3.0
-
-        with pytest.raises(WindowHeightValidationError) as exc_info:
-            WindowHeightValidator.validate_window_height_bounds(
-                window_geom, floor_height, roof_height
-            )
-
-        error_msg = str(exc_info.value)
-        assert "above roof" in error_msg
-        assert "3.50m" in error_msg
-        assert "3.00m" in error_msg
-
-    def test_window_both_below_and_above(self):
-        """Test window that extends both below floor and above roof (should fail on floor check first)."""
-        from src.core.exceptions import WindowHeightValidationError
-
-        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=-1.0, x2=1.0, y2=0.0, z2=4.0)
-        floor_height = 0.0
-        roof_height = 3.0
-
-        with pytest.raises(WindowHeightValidationError) as exc_info:
-            WindowHeightValidator.validate_window_height_bounds(
-                window_geom, floor_height, roof_height
-            )
-
-        error_msg = str(exc_info.value)
-        assert "below floor" in error_msg  # Floor check happens first
 
     def test_window_with_elevated_floor(self):
         """Test window with non-zero floor height."""
         window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=2.5, x2=1.0, y2=0.0, z2=4.0)
-        floor_height = 2.0
-        roof_height = 5.0
-
         is_valid, error_msg = WindowHeightValidator.validate_window_height_bounds(
-            window_geom, floor_height, roof_height
+            window_geom, floor_height=2.0, roof_height=5.0
         )
-
         assert is_valid is True
         assert error_msg == ""
-
-    def test_window_below_elevated_floor(self):
-        """Test window below elevated floor."""
-        from src.core.exceptions import WindowHeightValidationError
-
-        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=1.5, x2=1.0, y2=0.0, z2=3.0)
-        floor_height = 2.0
-        roof_height = 5.0
-
-        with pytest.raises(WindowHeightValidationError) as exc_info:
-            WindowHeightValidator.validate_window_height_bounds(
-                window_geom, floor_height, roof_height
-            )
-
-        error_msg = str(exc_info.value)
-        assert "below floor" in error_msg
-        assert "1.50m" in error_msg
-        assert "2.00m" in error_msg
 
     def test_window_with_reversed_z_coordinates(self):
         """Test window where z2 < z1 (should handle both orderings)."""
-        # z2 < z1, but window is still within bounds
         window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=2.5, x2=1.0, y2=0.0, z2=1.0)
-        floor_height = 0.0
-        roof_height = 3.0
-
         is_valid, error_msg = WindowHeightValidator.validate_window_height_bounds(
-            window_geom, floor_height, roof_height
+            window_geom, floor_height=0.0, roof_height=3.0
         )
-
         assert is_valid is True
         assert error_msg == ""
 
-    def test_window_within_tolerance(self):
-        """Test window that is within numerical tolerance of bounds."""
-        # GRAPHICS_CONSTANTS.WINDOW_HEIGHT_TOLERANCE is used
-        # Window bottom is slightly below floor but within tolerance
-        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=-1e-7, x2=1.0, y2=0.0, z2=2.0)
-        floor_height = 0.0
-        roof_height = 3.0
-
+    def test_realistic_scenario_valid(self):
+        """Test realistic scenario with typical building dimensions."""
+        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=1.0, x2=2.0, y2=0.0, z2=2.5)
         is_valid, error_msg = WindowHeightValidator.validate_window_height_bounds(
-            window_geom, floor_height, roof_height
+            window_geom, floor_height=0.3, roof_height=3.3
         )
-
         assert is_valid is True
         assert error_msg == ""
 
-    def test_window_outside_tolerance(self):
-        """Test window that is outside numerical tolerance."""
-        from src.core.exceptions import WindowHeightValidationError
+    def test_zero_height_room(self):
+        """Test edge case where floor and roof are at same height."""
+        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=1.0, x2=2.0, y2=0.0, z2=1.0)
+        is_valid, error_msg = WindowHeightValidator.validate_window_height_bounds(
+            window_geom, floor_height=1.0, roof_height=1.0
+        )
+        assert is_valid is True
+        assert error_msg == ""
 
-        # GRAPHICS_CONSTANTS.WINDOW_HEIGHT_TOLERANCE is used
-        # Window bottom is significantly below floor (outside tolerance)
-        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=-0.01, x2=1.0, y2=0.0, z2=2.0)
-        floor_height = 0.0
-        roof_height = 3.0
+    # --- Clamping: within 15cm tolerance ---
 
+    def test_window_bottom_clamped_to_floor(self):
+        """Test BIM window frame extending 10cm below floor is clamped."""
+        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=-0.10, x2=1.0, y2=0.0, z2=2.0)
+        is_valid, error_msg = WindowHeightValidator.validate_window_height_bounds(
+            window_geom, floor_height=0.0, roof_height=3.0
+        )
+        assert is_valid is True
+        assert window_geom.z1 == 0.0
+
+    def test_window_top_clamped_to_roof(self):
+        """Test BIM window frame extending 10cm above roof is clamped."""
+        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=1.0, x2=1.0, y2=0.0, z2=3.10)
+        is_valid, error_msg = WindowHeightValidator.validate_window_height_bounds(
+            window_geom, floor_height=0.0, roof_height=3.0
+        )
+        assert is_valid is True
+        assert window_geom.z2 == 3.0
+
+    def test_window_clamped_at_exact_tolerance_boundary(self):
+        """Test window at exactly 15cm deviation is still clamped."""
+        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=-0.15, x2=1.0, y2=0.0, z2=2.0)
+        is_valid, error_msg = WindowHeightValidator.validate_window_height_bounds(
+            window_geom, floor_height=0.0, roof_height=3.0
+        )
+        assert is_valid is True
+        assert window_geom.z1 == 0.0
+
+    def test_window_clamped_with_reversed_z(self):
+        """Test clamping works when z1 > z2 (reversed coordinates)."""
+        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=2.0, x2=1.0, y2=0.0, z2=-0.10)
+        is_valid, error_msg = WindowHeightValidator.validate_window_height_bounds(
+            window_geom, floor_height=0.0, roof_height=3.0
+        )
+        assert is_valid is True
+        assert window_geom.z2 == 0.0
+
+    def test_window_clamped_with_elevated_floor(self):
+        """Test clamping with non-zero floor height (BIM realistic)."""
+        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=0.2, x2=2.0, y2=0.0, z2=2.0)
+        is_valid, error_msg = WindowHeightValidator.validate_window_height_bounds(
+            window_geom, floor_height=0.3, roof_height=3.3
+        )
+        assert is_valid is True
+        assert window_geom.z1 == 0.3
+
+    def test_window_tiny_deviation_clamped(self):
+        """Test very small deviation (1mm) is clamped, not rejected."""
+        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=-0.001, x2=1.0, y2=0.0, z2=2.0)
+        is_valid, error_msg = WindowHeightValidator.validate_window_height_bounds(
+            window_geom, floor_height=0.0, roof_height=3.0
+        )
+        assert is_valid is True
+        assert window_geom.z1 == 0.0
+
+    # --- Errors: beyond 15cm tolerance ---
+
+    def test_window_below_floor_beyond_tolerance(self):
+        """Test window 50cm below floor raises error."""
+        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=-0.5, x2=1.0, y2=0.0, z2=2.0)
         with pytest.raises(WindowHeightValidationError) as exc_info:
             WindowHeightValidator.validate_window_height_bounds(
-                window_geom, floor_height, roof_height
+                window_geom, floor_height=0.0, roof_height=3.0
+            )
+        assert "below floor" in str(exc_info.value)
+
+    def test_window_above_roof_beyond_tolerance(self):
+        """Test window 50cm above roof raises error."""
+        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=2.0, x2=1.0, y2=0.0, z2=3.5)
+        with pytest.raises(WindowHeightValidationError) as exc_info:
+            WindowHeightValidator.validate_window_height_bounds(
+                window_geom, floor_height=0.0, roof_height=3.0
+            )
+        assert "above roof" in str(exc_info.value)
+
+    def test_window_both_below_and_above_beyond_tolerance(self):
+        """Test window extending far beyond both bounds fails on floor check first."""
+        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=-1.0, x2=1.0, y2=0.0, z2=4.0)
+        with pytest.raises(WindowHeightValidationError) as exc_info:
+            WindowHeightValidator.validate_window_height_bounds(
+                window_geom, floor_height=0.0, roof_height=3.0
+            )
+        assert "below floor" in str(exc_info.value)
+
+    def test_window_just_beyond_tolerance(self):
+        """Test window at 16cm deviation (just over 15cm) raises error."""
+        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=-0.16, x2=1.0, y2=0.0, z2=2.0)
+        with pytest.raises(WindowHeightValidationError):
+            WindowHeightValidator.validate_window_height_bounds(
+                window_geom, floor_height=0.0, roof_height=3.0
             )
 
-        error_msg = str(exc_info.value)
-        assert "below floor" in error_msg
+    def test_window_below_elevated_floor_beyond_tolerance(self):
+        """Test window far below elevated floor raises error."""
+        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=1.5, x2=1.0, y2=0.0, z2=3.0)
+        with pytest.raises(WindowHeightValidationError) as exc_info:
+            WindowHeightValidator.validate_window_height_bounds(
+                window_geom, floor_height=2.0, roof_height=5.0
+            )
+        assert "below floor" in str(exc_info.value)
+
+    def test_realistic_scenario_window_too_low(self):
+        """Test realistic scenario where window is far below floor."""
+        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=-0.5, x2=2.0, y2=0.0, z2=2.0)
+        with pytest.raises(WindowHeightValidationError) as exc_info:
+            WindowHeightValidator.validate_window_height_bounds(
+                window_geom, floor_height=0.3, roof_height=3.3
+            )
+        assert "below floor" in str(exc_info.value)
+
+    def test_realistic_scenario_window_too_high(self):
+        """Test realistic scenario where window extends far above roof."""
+        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=2.0, x2=2.0, y2=0.0, z2=3.5)
+        with pytest.raises(WindowHeightValidationError) as exc_info:
+            WindowHeightValidator.validate_window_height_bounds(
+                window_geom, floor_height=0.3, roof_height=3.3
+            )
+        assert "above roof" in str(exc_info.value)
+
+    def test_zero_height_room_window_with_height(self):
+        """Test window with height in zero-height room (should fail)."""
+        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=1.0, x2=2.0, y2=0.0, z2=1.5)
+        with pytest.raises(WindowHeightValidationError) as exc_info:
+            WindowHeightValidator.validate_window_height_bounds(
+                window_geom, floor_height=1.0, roof_height=1.0
+            )
+        assert "above roof" in str(exc_info.value)
+
+    # --- validate_from_parameters ---
 
     def test_validate_from_parameters_valid(self):
         """Test validation from parameter dictionaries with valid window."""
         window_data = {"x1": 0.0, "y1": 0.0, "z1": 1.0, "x2": 1.0, "y2": 0.0, "z2": 2.5}
-        floor_height = 0.0
-        roof_height = 3.0
-
         is_valid, error_msg = WindowHeightValidator.validate_from_parameters(
-            window_data, floor_height, roof_height
+            window_data, floor_height=0.0, roof_height=3.0
         )
-
         assert is_valid is True
         assert error_msg == ""
 
     def test_validate_from_parameters_below_floor(self):
-        """Test validation from parameters with window below floor."""
+        """Test validation from parameters with window far below floor."""
         window_data = {"x1": 0.0, "y1": 0.0, "z1": -0.5, "x2": 1.0, "y2": 0.0, "z2": 2.0}
-        floor_height = 0.0
-        roof_height = 3.0
-
         is_valid, error_msg = WindowHeightValidator.validate_from_parameters(
-            window_data, floor_height, roof_height
+            window_data, floor_height=0.0, roof_height=3.0
         )
-
         assert is_valid is False
         assert "below floor" in error_msg
 
     def test_validate_from_parameters_above_roof(self):
-        """Test validation from parameters with window above roof."""
+        """Test validation from parameters with window far above roof."""
         window_data = {"x1": 0.0, "y1": 0.0, "z1": 2.0, "x2": 1.0, "y2": 0.0, "z2": 3.5}
-        floor_height = 0.0
-        roof_height = 3.0
-
         is_valid, error_msg = WindowHeightValidator.validate_from_parameters(
-            window_data, floor_height, roof_height
+            window_data, floor_height=0.0, roof_height=3.0
         )
-
         assert is_valid is False
         assert "above roof" in error_msg
 
     def test_validate_from_parameters_missing_z_coordinate(self):
         """Test validation with missing z coordinate in data."""
-        window_data = {"x1": 0.0, "y1": 0.0, "z1": 1.0, "x2": 1.0, "y2": 0.0}  # Missing z2
-        floor_height = 0.0
-        roof_height = 3.0
-
+        window_data = {"x1": 0.0, "y1": 0.0, "z1": 1.0, "x2": 1.0, "y2": 0.0}
         is_valid, error_msg = WindowHeightValidator.validate_from_parameters(
-            window_data, floor_height, roof_height
+            window_data, floor_height=0.0, roof_height=3.0
         )
-
         assert is_valid is False
         assert "Error parsing height data" in error_msg
 
     def test_validate_from_parameters_invalid_data_type(self):
         """Test validation with invalid data type."""
         window_data = {"x1": "invalid", "y1": 0.0, "z1": 1.0, "x2": 1.0, "y2": 0.0, "z2": 2.0}
-        floor_height = 0.0
-        roof_height = 3.0
-
         is_valid, error_msg = WindowHeightValidator.validate_from_parameters(
-            window_data, floor_height, roof_height
+            window_data, floor_height=0.0, roof_height=3.0
         )
-
         assert is_valid is False
         assert "Error parsing height data" in error_msg
-
-    def test_realistic_scenario_valid(self):
-        """Test realistic scenario with typical building dimensions."""
-        # Floor at 0.3m above terrain, roof at 3.0m above floor
-        # Window from 1.0m to 2.5m (valid)
-        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=1.0, x2=2.0, y2=0.0, z2=2.5)
-        floor_height = 0.3
-        roof_height = 0.3 + 3.0  # 3.3m
-
-        is_valid, error_msg = WindowHeightValidator.validate_window_height_bounds(
-            window_geom, floor_height, roof_height
-        )
-
-        assert is_valid is True
-        assert error_msg == ""
-
-    def test_realistic_scenario_window_too_low(self):
-        """Test realistic scenario where window sill is below floor."""
-        from src.core.exceptions import WindowHeightValidationError
-
-        # Floor at 0.3m, but window starts at 0.2m (below floor)
-        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=0.2, x2=2.0, y2=0.0, z2=2.0)
-        floor_height = 0.3
-        roof_height = 3.3
-
-        with pytest.raises(WindowHeightValidationError) as exc_info:
-            WindowHeightValidator.validate_window_height_bounds(
-                window_geom, floor_height, roof_height
-            )
-
-        error_msg = str(exc_info.value)
-        assert "below floor" in error_msg
-
-    def test_realistic_scenario_window_too_high(self):
-        """Test realistic scenario where window extends above roof."""
-        from src.core.exceptions import WindowHeightValidationError
-
-        # Roof at 3.3m, but window goes to 3.5m
-        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=2.0, x2=2.0, y2=0.0, z2=3.5)
-        floor_height = 0.3
-        roof_height = 3.3
-
-        with pytest.raises(WindowHeightValidationError) as exc_info:
-            WindowHeightValidator.validate_window_height_bounds(
-                window_geom, floor_height, roof_height
-            )
-
-        error_msg = str(exc_info.value)
-        assert "above roof" in error_msg
-
-    def test_zero_height_room(self):
-        """Test edge case where floor and roof are at same height."""
-        # Floor and roof at same height - window can only be a line
-        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=1.0, x2=2.0, y2=0.0, z2=1.0)
-        floor_height = 1.0
-        roof_height = 1.0
-
-        is_valid, error_msg = WindowHeightValidator.validate_window_height_bounds(
-            window_geom, floor_height, roof_height
-        )
-
-        assert is_valid is True
-        assert error_msg == ""
-
-    def test_zero_height_room_window_with_height(self):
-        """Test window with height in zero-height room (should fail)."""
-        from src.core.exceptions import WindowHeightValidationError
-
-        window_geom = WindowGeometry(x1=0.0, y1=0.0, z1=1.0, x2=2.0, y2=0.0, z2=1.5)
-        floor_height = 1.0
-        roof_height = 1.0
-
-        with pytest.raises(WindowHeightValidationError) as exc_info:
-            WindowHeightValidator.validate_window_height_bounds(
-                window_geom, floor_height, roof_height
-            )
-
-        error_msg = str(exc_info.value)
-        assert "above roof" in error_msg


### PR DESCRIPTION
## Summary
window frames extend slightly beyond floor/roof boundaries. Instead of rejecting these windows, they are now clamped to floor/roof when the deviation is within 15cm tolerance.

Added z1/z2 setters to WindowGeometry that keep cached _z_min/_z_max in sync.

Renamed WINDOW_HEIGHT_TOLERANCE to WINDOW_HEIGHT_CORRECTION_TOLERANCE (15cm) to reflect the new clamping behavior.