### PR TITLE
Make the encoding service concurrency-safe (per-request builder + region encoders) - v2

### DIFF
--- a/src/components/region_encoders/region_encoder_factory.py
+++ b/src/components/region_encoders/region_encoder_factory.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from src.core import RegionType, EncodingScheme
 from src.components.region_encoders.background_region_encoder import BackgroundRegionEncoder
 from src.components.region_encoders.base_region_encoder import BaseRegionEncoder
@@ -12,14 +10,19 @@ _V2_EQUIVALENT_SCHEMES = frozenset({EncodingScheme.V3, EncodingScheme.V4})
 
 
 class RegionEncoderFactory:
-    """Factory for creating region encoders (Factory Pattern + Singleton per encoding scheme)"""
+    """Factory for creating region encoders (Factory Pattern).
 
-    _instances: Dict[tuple, BaseRegionEncoder] = {}
+    A fresh encoder is created on every call. Region encoders carry mutable
+    per-request state (BaseRegionEncoder._last_mask, set during encode_region
+    and read back via get_last_mask), so they must NOT be cached/shared across
+    concurrent requests - otherwise one request's room mask leaks into another's.
+    Construction is cheap.
+    """
 
     @classmethod
     def get_encoder(cls, region_type: RegionType, encoding_scheme: EncodingScheme = EncodingScheme.V2) -> BaseRegionEncoder:
         """
-        Get encoder for a region type and encoding scheme (Singleton pattern per encoding scheme).
+        Create a fresh region encoder for a region type and encoding scheme.
 
         V3 and V4 reuse V2 encoders for all non-obstruction regions; their obstruction
         behaviour is handled separately by ObstructionEncodingStrategy subclasses.
@@ -29,29 +32,25 @@ class RegionEncoderFactory:
             encoding_scheme: The encoding scheme (default: V2)
 
         Returns:
-            Region encoder instance
+            A new region encoder instance
         """
         # V3/V4 use V2 encoders for background/room/window regions
         effective_scheme = (
             EncodingScheme.V2 if encoding_scheme in _V2_EQUIVALENT_SCHEMES else encoding_scheme
         )
-        cache_key = (region_type, effective_scheme)
 
-        if cache_key not in cls._instances:
-            obstruction_encoder = (
-                V11ObstructionBarEncoder if effective_scheme == EncodingScheme.V11 else ObstructionBarEncoder
-            )
-            encoder_map = {
-                RegionType.BACKGROUND: BackgroundRegionEncoder,
-                RegionType.ROOM: RoomRegionEncoder,
-                RegionType.WINDOW: WindowRegionEncoder,
-                RegionType.OBSTRUCTION_BAR: obstruction_encoder,
-            }
+        obstruction_encoder = (
+            V11ObstructionBarEncoder if effective_scheme == EncodingScheme.V11 else ObstructionBarEncoder
+        )
+        encoder_map = {
+            RegionType.BACKGROUND: BackgroundRegionEncoder,
+            RegionType.ROOM: RoomRegionEncoder,
+            RegionType.WINDOW: WindowRegionEncoder,
+            RegionType.OBSTRUCTION_BAR: obstruction_encoder,
+        }
 
-            encoder_class = encoder_map.get(region_type)
-            if not encoder_class:
-                raise ValueError(f"Unknown region type: {region_type}")
+        encoder_class = encoder_map.get(region_type)
+        if not encoder_class:
+            raise ValueError(f"Unknown region type: {region_type}")
 
-            cls._instances[cache_key] = encoder_class(encoding_scheme=effective_scheme)
-
-        return cls._instances[cache_key]
+        return encoder_class(encoding_scheme=effective_scheme)

--- a/src/server/services/encoding_service.py
+++ b/src/server/services/encoding_service.py
@@ -24,10 +24,22 @@ class EncodingService:
 
     def __init__(self, encoding_scheme: EncodingScheme = EncodingScheme.V2):
         self._encoding_scheme = encoding_scheme
-        self._builder = RoomImageBuilder(encoding_scheme=encoding_scheme)
-        self._director = RoomImageDirector(self._builder, encoding_scheme=encoding_scheme)
         self._encoder_factory = EncoderFactory()
         self._validator = EncodingParameterValidator(encoding_scheme, self._encoder_factory)
+
+    def _create_director(self) -> RoomImageDirector:
+        """Create a fresh, request-local image director.
+
+        The director and its RoomImageBuilder hold mutable per-request state
+        (the image being built and the room mask). Because the encoding
+        services are reused as shared singletons, that state must never live on
+        the service: concurrent encode calls would otherwise interleave on the
+        same buffers and corrupt each other's image/mask (e.g. an empty
+        (128, 128, 4) room mask leaking out mid-build). A fresh director per
+        encode call keeps every request fully isolated.
+        """
+        builder = RoomImageBuilder(encoding_scheme=self._encoding_scheme)
+        return RoomImageDirector(builder, encoding_scheme=self._encoding_scheme)
 
     def parse_request(self, data: Dict[str, Any]) -> RoomEncodingRequest:
         try:
@@ -75,7 +87,8 @@ class EncodingService:
 
         logger.info(f"Encoding room image arrays - model_type: {model_type.value}, param_count: {len(parameters)}")
 
-        image_array, mask_array = self._director.construct_from_flat_parameters(model_type, parameters)
+        director = self._create_director()
+        image_array, mask_array = director.construct_from_flat_parameters(model_type, parameters)
         image_array = image_array.astype(np.uint8)
 
         if self._encoding_scheme in (EncodingScheme.V9, EncodingScheme.V10, EncodingScheme.V11):
@@ -136,7 +149,8 @@ class EncodingService:
             logger.error(f"Parameter validation failed: {error_msg}")
             raise ValueError(error_msg)
 
-        result = self._director.construct_multi_window_images(model_type, parameters)
+        director = self._create_director()
+        result = director.construct_multi_window_images(model_type, parameters)
 
         for window_id in result.window_ids():
             img = result.images[window_id].astype(np.uint8)
@@ -163,7 +177,8 @@ class EncodingService:
             f"window_count: {len(parameters[ParameterName.WINDOWS.value])}"
         )
 
-        array_result = self._director.construct_multi_window_images(model_type, parameters)
+        director = self._create_director()
+        array_result = director.construct_multi_window_images(model_type, parameters)
 
         result = EncodedBytesResult()
         for window_id in array_result.window_ids():

--- a/src/server/services/encoding_service_v12.py
+++ b/src/server/services/encoding_service_v12.py
@@ -65,7 +65,8 @@ class V12EncodingService(EncodingService):
         if not is_valid:
             raise ValueError(error_msg)
 
-        image, mask = self._director.construct_from_flat_parameters(model_type, parameters)
+        director = self._create_director()
+        image, mask = director.construct_from_flat_parameters(model_type, parameters)
         static_vector = self._build_static_vector(parameters)
         return image, mask, static_vector
 

--- a/src/server/services/encoding_service_v5.py
+++ b/src/server/services/encoding_service_v5.py
@@ -43,9 +43,17 @@ class V5EncodingService(EncodingService):
     def __init__(self, encoding_scheme: EncodingScheme = EncodingScheme.V5) -> None:
         # Bypass EncodingService.__init__: RGBA builder/director not needed here
         self._encoding_scheme = encoding_scheme
-        self._director = V6ImageDirector() if encoding_scheme == EncodingScheme.V6 else V5ImageDirector()
         self._encoder_factory = EncoderFactory()
         self._validator = EncodingParameterValidator(encoding_scheme, self._encoder_factory)
+
+    def _create_director(self):
+        """Create a fresh, request-local V5/V6 director.
+
+        The director holds mutable per-request build state, so it must not be
+        shared across concurrent requests via the singleton service (see
+        EncodingService._create_director).
+        """
+        return V6ImageDirector() if self._encoding_scheme == EncodingScheme.V6 else V5ImageDirector()
 
     # ------------------------------------------------------------------
     # Validation
@@ -122,7 +130,8 @@ class V5EncodingService(EncodingService):
 
         logger.info("Encoding V%s mask - model_type: %s", self._encoding_scheme.value, model_type.value)
 
-        result = self._director.construct_from_flat_parameters(model_type, parameters)
+        director = self._create_director()
+        result = director.construct_from_flat_parameters(model_type, parameters)
         image_array = result[0]
         mask_array = result[1]
 
@@ -146,7 +155,8 @@ class V5EncodingService(EncodingService):
             self._encoding_scheme.value, model_type.value,
             len(parameters[ParameterName.WINDOWS.value]),
         )
-        result = self._director.construct_multi_window_images(model_type, parameters)
+        director = self._create_director()
+        result = director.construct_multi_window_images(model_type, parameters)
         logger.info("Multi-window V%s masks encoded - count: %d", self._encoding_scheme.value, len(result.images))
         return result
 
@@ -177,7 +187,8 @@ class V5EncodingService(EncodingService):
 
         logger.info("Encoding V6 image - model_type: %s, param_count: %d", model_type.value, len(parameters))
 
-        image_array, mask_array, static_vector = self._director.construct_from_flat_parameters(
+        director = self._create_director()
+        image_array, mask_array, static_vector = director.construct_from_flat_parameters(
             model_type, parameters
         )
 
@@ -208,7 +219,8 @@ class V5EncodingService(EncodingService):
             "Encoding multi-window V6 - model_type: %s, window_count: %d",
             model_type.value, len(parameters[ParameterName.WINDOWS.value]),
         )
-        result = self._director.construct_multi_window_images(model_type, parameters)
+        director = self._create_director()
+        result = director.construct_multi_window_images(model_type, parameters)
         logger.info("Multi-window V6 encoded - count: %d", len(result.images))
         return result  # type: ignore[return-value]
 


### PR DESCRIPTION
Problem
Under concurrent requests, identical input produced non-deterministic / corrupted
daylight results — hard edges, missing window contributions, and occasional worker
crashes. Inputs, the ONNX model and the encoded image were all verified deterministic;
the variance only appeared under concurrency.

Root cause
Shared singletons holding mutable per-request state:

EncodingService (reused as a singleton, also held for the app lifetime) stored a
stateful RoomImageBuilder / RoomImageDirector on self (self._image,
self._room_mask).
RegionEncoderFactory cached region encoders class-wide, and BaseRegionEncoder
keeps the last computed mask on self._last_mask (read back via get_last_mask).
With gunicorn --threads and the caller's per-window fan-out, concurrent encodes
interleaved on those shared buffers: an empty (128,128,4) buffer leaked into the mask
slot, encoded images/masks were corrupted, and the merged field became non-deterministic.

Changes
Create a fresh RoomImageDirector / RoomImageBuilder per encode call; services keep
only stateless config. Subclasses override _create_director() (V5/V6, V12/V13).
RegionEncoderFactory no longer caches — constructs a fresh encoder per call.
Each request is now fully isolated.

Testing
30 concurrent /run requests, identical payload: 0 failures, bit-identical result
(previously ~50% failures + 12 distinct results). Per-window fields and masks are stable.